### PR TITLE
Fixes bug #16 : Runtime error in a Xamarin.UWP project

### DIFF
--- a/DM.MovieApi/ApiRequest/ApiRequestBase.cs
+++ b/DM.MovieApi/ApiRequest/ApiRequestBase.cs
@@ -142,7 +142,6 @@ namespace DM.MovieApi.ApiRequest
             var handler = new HttpClientHandler
             {
                 AllowAutoRedirect = false,
-                PreAuthenticate = false,
                 UseCookies = false,
                 UseDefaultCredentials = true,
                 AutomaticDecompression = DecompressionMethods.GZip,


### PR DESCRIPTION
https://github.com/nCubed/TheMovieDbWrapper/issues/16 Runtime error in a Xamarin.UWP project

Fixed it by removing line 145 from ApiRequestBase.cs:

    PreAuthenticate = false,

This should have no side-effects as PreAuthenticate defaults to false anyway. 